### PR TITLE
Typed some things

### DIFF
--- a/examples/typed/funky-town.rkt
+++ b/examples/typed/funky-town.rkt
@@ -1,0 +1,11 @@
+#lang synth/typed
+
+#:output "funky-town.wav"
+#:bpm 380
+
+(sequence
+ sawtooth-wave #:bpm 380 #:times 2
+ [(C 5) #f (C 5) #f (A# 4) #f (C 5) (#f 3) (G 4) (#f 3)
+  (G 4) #f (C 5) #f (F 5) #f (E 5) #f (C 5) (#f 9)])
+
+(drum #:bpm 380 #:times 8 (O #f #f #f X #f #f #f))

--- a/typed/drum.rkt
+++ b/typed/drum.rkt
@@ -1,0 +1,68 @@
+#lang typed/racket/base
+
+(require math/array)
+
+(require "synth.rkt")
+
+(provide drum Drum-Symbol Pattern)
+
+(define-type Drum-Symbol (U 'O 'X #f))
+(define-type Pattern (Listof Drum-Symbol))
+
+(: random-sample (-> Float))
+(define (random-sample) (- (* 2.0 (random)) 1.0))
+
+;; Drum "samples" (Arrays of floats)
+;; TODO compute those at compile-time
+(: bass-drum (Array Float))
+(define bass-drum
+  (let ()
+    ;; 0.05 seconds of noise whose value changes every 12 samples
+    (: n-samples Integer)
+    (define n-samples           (seconds->samples 0.05))
+    (: n-different-samples Integer)
+    (define n-different-samples (quotient n-samples 12))
+    (: ds In-Indexes)
+    (define ds (vector n-samples))
+    (for/array: #:shape ds
+               #:fill 0.0
+               ([i (in-range n-different-samples)]
+                [sample (in-producer random-sample (lambda _ #f))]
+                #:when #t
+                [j (in-range 12)]) : Float
+       sample)))
+
+(: snare (Array Float))
+(define snare
+  ;; 0.05 seconds of noise
+  (let: ([indexes : In-Indexes
+                  (vector (seconds->samples 0.05))]
+         [arr-gen : (-> Indexes Flonum)
+                  (lambda ([x : Indexes]) (random-sample))])
+    (build-array indexes arr-gen)))
+
+;; limited drum machine
+(: drum (-> Natural Pattern Natural (Array Float)))
+(define (drum n pattern tempo)
+  (: samples-per-beat Natural)
+  (define samples-per-beat (quotient (* fs 60) tempo))
+  (: make-drum (-> (Array Float) Natural (Array Float)))
+  (define (make-drum drum-sample samples-per-beat)
+    (array-append*
+     (list drum-sample
+           (make-array (vector (- samples-per-beat
+                                  (array-size drum-sample)))
+                       0.0))))
+  (: O (Array Float))
+  (define O     (make-drum bass-drum samples-per-beat))
+  (: X (Array Float))
+  (define X     (make-drum snare     samples-per-beat))
+  (: pause (Array Float))
+  (define pause (make-array (vector samples-per-beat) 0.0))
+  (array-append*
+   (for*/list : (Listof (Array Float)) ([i : Integer (in-range n)]
+                                        [beat : Drum-Symbol (in-list pattern)])
+     (case beat
+       [(X)  X]
+       [(O)  O]
+       [(#f) pause]))))

--- a/typed/main.rkt
+++ b/typed/main.rkt
@@ -1,0 +1,73 @@
+#lang typed/racket
+
+(require "synth.rkt" "sequencer.rkt" "mixer.rkt" "drum.rkt")
+(provide (except-out (all-from-out "synth.rkt"
+                                   "sequencer.rkt"
+                                   "mixer.rkt"
+                                   "drum.rkt")
+                     mix sequence drum)
+         (rename-out [mix/export      mix]
+                     [sequence/export sequence]
+                     [drum/export     drum]
+                     [#%module-begin/export #%module-begin])
+         #;(except-out (all-from-out typed/racket) provide #%module-begin))
+
+(require (for-syntax syntax/parse) racket/stxparam)
+
+(define-syntax-parameter current-bpm (syntax-rules ()))
+
+(begin-for-syntax
+ (define-syntax-class mixand
+   #:attributes (signal weight)
+   (pattern [signal:expr (~datum #:weight) weight:expr])
+   (pattern signal:expr #:with weight #'1))
+ )
+
+(define-syntax (mix/export stx)
+  (syntax-parse stx
+    [(_ sig:mixand ...)
+     #'(mix (list sig.signal sig.weight) ...)]))
+
+(begin-for-syntax
+ (define-syntax-class sequend
+   #:attributes (res)
+   (pattern (~datum #f) ; break of 1 unit
+            #:with res #''[(#f . 1)])
+   (pattern [(~datum #f) len:expr]
+            #:with res #'`[,(cons #f len)])
+   (pattern ((~literal chord) root octave duration type notes* ...)
+            ;; TODO this syntax is not as nice as the others
+            #:with res #'`[,(chord 'root octave duration 'type notes* ...)])
+   (pattern ((~literal scale) root octave duration type notes* ...)
+            ;; TODO this syntax is not as nice as the others
+            #:with res #'(scale 'root octave duration 'type notes* ...))
+   (pattern [n:id octave:expr] ; note of 1 unit
+            ;; TODO id is too permissive
+            #:with res #'`[,(note 'n octave 1)])
+   (pattern [n:id octave:expr len:expr]
+            #:with res #'`[,(note 'n octave len)]))
+ )
+
+(define-syntax (sequence/export stx)
+  (syntax-parse stx
+    ;; TODO OoO keywords, support for repetitions
+    [(_ function:expr (~datum #:bpm) bpm:expr (~datum #:times) times:expr
+        [note:sequend ...])
+     #'(sequence times (list note.res ...) bpm function)]))
+
+(define-syntax (drum/export stx)
+  (syntax-parse stx
+    [(_ (~datum #:bpm) bpm:expr (~datum #:times) times:expr [notes ...])
+     #'(drum times '(notes ...) bpm)]))
+
+(module reader syntax/module-reader
+  #:language 'synth)
+
+(define-syntax (#%module-begin/export stx)
+  (syntax-parse stx
+    [(_ #:output output:expr #:bpm bpm:expr
+        signal ...)
+     #'(#%module-begin
+        (syntax-parameterize
+         ([current-bpm (syntax-rules () [(_) bpm])])
+         (emit (mix/export signal ...) output)))]))

--- a/typed/mixer.rkt
+++ b/typed/mixer.rkt
@@ -1,0 +1,37 @@
+#lang typed/racket
+
+(require math/array)
+
+(provide mix Weighted-Signal)
+
+;; A Weighted-Signal is a (List (Array Float) Real)
+
+;; Weighted sum of signals, receives a list of lists (signal weight).
+;; Shorter signals are repeated to match the length of the longest.
+;; Normalizes output to be within [-1,1].
+(define-type Weighted-Signal (List (Array Float) Real))
+
+(: mix (-> Weighted-Signal * (Array Float)))
+(define (mix . ss)
+  (: signals (Listof (Array Float)))
+  (define signals
+    (for/list : (Listof (Array Float)) ([s : Weighted-Signal ss])
+      (first s)))
+  (: weights (Listof Float))
+  (define weights
+    (for/list : (Listof Float) ([x : Weighted-Signal ss])
+      (real->double-flonum (second x))))
+  (: downscale-ratio Float)
+  (define downscale-ratio (/ 1.0 (apply + weights)))
+  (: scale-signal (Float -> (Float -> Float)))
+  (define ((scale-signal w) x) (* x w downscale-ratio))
+  (parameterize ([array-broadcasting 'permissive]) ; repeat short signals
+    (for/fold ([res : (Array Float) (array-map (scale-signal (first weights))
+                               (first signals))])
+        ([s (in-list (rest signals))]
+         [w (in-list (rest weights))])
+      (define scale (scale-signal w))
+      (array-map (lambda ([acc : Float]
+                          [new : Float])
+                   (+ acc (scale new)))
+                 res s))))

--- a/typed/sequencer.rkt
+++ b/typed/sequencer.rkt
@@ -1,0 +1,67 @@
+#lang typed/racket
+
+(require math/array racket/flonum racket/unsafe/ops)
+
+(require "synth.rkt" "mixer.rkt")
+
+(provide note sequence)
+
+;; details at http://www.phy.mtu.edu/~suits/notefreqs.html
+(: note-freq (-> Natural Float))
+(define (note-freq note)
+  ;; A4 (440Hz) is 57 semitones above C0, which is our base.
+  (: res Nonnegative-Real)
+  (define res (* 440 (expt (expt 2 1/12) (- note 57))))
+  (if (flonum? res) res (error "not real")))
+
+;; A note is represented using the number of semitones from C0.
+(: name+octave->note (-> Symbol Natural Natural))
+(define (name+octave->note name octave)
+  (+ (* 12 octave)
+     (case name
+       [(C) 0]
+       [(C# Db) 1]
+       [(D) 2]
+       [(D# Eb) 3]
+       [(E) 4]
+       [(F) 5]
+       [(F# Gb) 6]
+       [(G) 7]
+       [(G# Ab) 8]
+       [(A) 9]
+       [(A# Bb) 10]
+       [(B) 11]
+       [else 0])))
+
+;; Single note.
+(: note (-> Symbol Natural Natural (Pairof Natural Natural)))
+(define (note name octave duration)
+  (cons (name+octave->note name octave) duration))
+
+;; Accepts notes or pauses, but not chords.
+(: synthesize-note (-> (U #f Natural)
+                       Natural
+                       (-> Float (-> Indexes Float))
+                       (Array Float)))
+(define (synthesize-note note n-samples function)
+  (build-array (vector n-samples)
+               (if note
+                   (function (note-freq note))
+                   (lambda (x) 0.0)))) ; pause
+
+;; repeats n times the sequence encoded by the pattern, at tempo bpm
+;; pattern is a list of either single notes (note . duration) or
+;; chords ((note ...) . duration) or pauses (#f . duration)
+(: sequence (-> Natural
+                (Listof (Pairof (U Natural #f) Natural))
+                Natural
+                (-> Float (-> Indexes Float)) (Array Float)))
+(define (sequence n pattern tempo function)
+  (: samples-per-beat Natural)
+  (define samples-per-beat (quotient (* fs 60) tempo))
+  (array-append*
+   (for*/list : (Listof (Array Float)) ([i   (in-range n)] ; repeat the whole pattern
+                                        [note : (Pairof (U Natural #f) Natural) (in-list  pattern)])
+     (: nsamples Natural)
+     (define nsamples (* samples-per-beat (cdr note)))
+     (synthesize-note (car note) nsamples function))))

--- a/typed/synth.rkt
+++ b/typed/synth.rkt
@@ -1,0 +1,88 @@
+#lang typed/racket
+
+(provide
+  fs
+  sawtooth-wave
+  seconds->samples
+  emit)
+
+(require math/array)
+
+(require "wav-encode.rkt") ;; TODO does not accept arrays directly
+
+;; TODO try to get deforestation for arrays. does that require
+;;   non-strict arrays? lazy arrays?
+(array-strictness #f)
+;; TODO this slows down a bit, it seems, but improves memory use
+
+
+(: fs Natural)
+(define fs 44100)
+(: bits-per-sample Natural)
+(define bits-per-sample 16)
+
+;; Wow this is too much work
+(: freq->sample-period (-> Float Integer))
+(define (freq->sample-period freq)
+  (: res Exact-Rational)
+  (define res (inexact->exact (round (/ fs freq))))
+  (if (index? res) res (error "not index")))
+
+(: seconds->samples (-> Float Integer))
+(define (seconds->samples s)
+  (: res Exact-Rational)
+  (define res (inexact->exact (round (* s fs))))
+  (if (index? res) res (error "not index")))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Oscillators
+
+;; array functions receive a vector of indices
+(define-syntax-rule (array-lambda (i) body ...)
+  (lambda ([i* : Indexes])
+    (let: ([i : Integer (vector-ref i* 0)]) body ...)))
+
+(: make-sawtooth-wave (-> Float (-> Float (-> Indexes Float))))
+(define ((make-sawtooth-wave coeff) freq)
+  (: sample-period Integer)
+  (define sample-period (freq->sample-period freq))
+  (: sample-period/2 Integer)
+  (define sample-period/2 (quotient sample-period 2))
+  (array-lambda (x)
+    ;; gradually goes from -1 to 1 over the whole cycle
+    (: x* Float)
+    (define x* (exact->inexact (modulo x sample-period)))
+    (* coeff (- (/ x* sample-period/2) 1.0))))
+(: sawtooth-wave (-> Float (-> Indexes Float)))
+(define sawtooth-wave         (make-sawtooth-wave 1.0))
+
+;; TODO make sure that all of these actually produce the right frequency
+;;  (i.e. no off-by-an-octave errors)
+
+;; TODO add weighted-harmonics, so we can approximate instruments
+;;  and take example from old synth
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(provide emit); plot-signal)
+
+;; assumes array of floats in [-1.0,1.0]
+;; assumes gain in [0,1], which determines how loud the output is
+(: signal->integer-sequence (-> (Array Float) [#:gain Float] (Vectorof Integer)))
+(define (signal->integer-sequence signal #:gain [gain 1])
+  (for/vector : (Vectorof Integer) #:length (array-size signal)
+              ([sample : Float (in-array signal)])
+    (max 0 (min (sub1 (expt 2 bits-per-sample)) ; clamp
+                (exact-floor
+                 (* gain
+                    (* (+ sample 1.0) ; center at 1, instead of 0
+                       (expt 2 (sub1 bits-per-sample)))))))))
+
+
+(: emit (-> (Array Float) Path-String Void))
+(define (emit signal file)
+  (with-output-to-file file #:exists 'replace
+    (lambda () (write-wav (signal->integer-sequence signal #:gain 0.3)))))
+

--- a/typed/tests.rkt
+++ b/typed/tests.rkt
@@ -1,0 +1,45 @@
+#lang racket
+
+(require math/array "synth.rkt" "sequencer.rkt" "mixer.rkt")
+
+;; (define sin-test (build-array `#(,(seconds->samples 2)) (sine-wave 440)))
+;; (define square-test (build-array `#(,(seconds->samples 2)) (square-wave 440)))
+;; (define sawtooth-test (build-array `#(,(seconds->samples 2)) (sawtooth-wave 440)))
+;; (define inverse-sawtooth-test (build-array `#(,(seconds->samples 2)) (sawtooth-wave 440)))
+;; (define triangle-test (build-array `#(,(seconds->samples 2)) (triangle-wave 440)))
+
+;; (emit sin-test "sin.wav")
+;; (emit square-test "square.wav")
+;; (emit sawtooth-test "sawtooth.wav")
+;; (emit inverse-sawtooth-test "inverse-sawtooth.wav")
+;; (emit triangle-test "triangle.wav")
+
+;; (plot-signal (build-array #(200) (sine-wave 440)))
+;; (plot-signal (build-array #(2000) (square-wave 440)))
+;; (plot-signal (build-array #(2000) (sawtooth-wave 440)))
+;; (plot-signal (build-array #(2000) (inverse-sawtooth-wave 440)))
+;; (plot-signal (build-array #(2000) (triangle-wave 440)))
+
+
+;; (emit (mix (list (sequence 3 (scale 'C 3 1 'major) 240 sine-wave)
+;;                  0.5)
+;;            (list (sequence 1 (scale 'C 4 1 'major-arpeggio) 120 sine-wave)
+;;                  0.5))
+;;       "scale.wav")
+
+;; ;; TODO have a better data entry method, esp. for pauses
+;; (emit (sequence 3 (list (chord 'C 4 2 'major-arpeggio)
+;;                         (chord 'C 4 1 'minor-arpeggio)
+;;                         '(#f . 2))
+;;                 120 sine-wave)
+;;       "chords.wav")
+
+(time (emit (mix (list (sequence 2 (list (chord 'C 3 3 'major-arpeggio)
+                                         (chord 'C 3 3 'minor-arpeggio))
+                                 120 square-wave)
+                       1)
+                 (list (sequence 2 (append (scale 'C 4 1 'major-arpeggio)
+                                           (scale 'C 4 1 'minor-arpeggio))
+                                 120 sawtooth-wave)
+                       2))
+            "arpeggio.wav"))

--- a/typed/wav-encode.rkt
+++ b/typed/wav-encode.rkt
@@ -1,0 +1,62 @@
+#lang typed/racket/base
+
+;; Simple WAVE encoder
+
+;; Very helpful reference:
+;; http://ccrma.stanford.edu/courses/422/projects/WaveFormat/
+
+(provide write-wav)
+(require racket/sequence)
+
+;; A WAVE file has 3 parts:
+;;  - the RIFF header: identifies the file as WAVE
+;;  - fmt subchunk: describes format of the data subchunk
+;;  - data subchunk
+
+;; data : sequence of 32-bit unsigned integers
+(: write-wav (->* ((Sequenceof Integer))
+                  (#:num-channels (U 1 2)
+                   #:sample-rate Natural
+                   #:bits-per-sample Natural)
+                  Void))
+(define (write-wav data
+                   #:num-channels    [num-channels    1] ; 1 = mono, 2 = stereo
+                   #:sample-rate     [sample-rate     44100]
+                   #:bits-per-sample [bits-per-sample 16])
+  (: bytes-per-sample Integer)
+  (define bytes-per-sample
+    (let ([i (quotient bits-per-sample 8)])
+      (unless (integer? i) (error "write-wav")) i))
+  (: write-integer-bytes (->* (Integer) (Integer) Integer))
+  (define (write-integer-bytes i [size 4])
+    (write-bytes (integer->integer-bytes i size #f)))
+  (: data-subchunk-size Integer)
+  (define data-subchunk-size
+    (let ([i (* (sequence-length data) num-channels (/ bits-per-sample 8))])
+      (unless (integer? i) (error "write-wav")) i))
+
+  ;; RIFF header
+  (write-bytes #"RIFF")
+  ;; 4 bytes: 4 + (8 + size of fmt subchunk) + (8 + size of data subchunk)
+  (write-integer-bytes (+ 36 data-subchunk-size))
+  (write-bytes #"WAVE")
+
+  ;; fmt subchunk
+  (write-bytes #"fmt ")
+  ;; size of the rest of the subchunk: 16 for PCM
+  (write-integer-bytes 16)
+  ;; audio format: 1 = PCM
+  (write-integer-bytes 1 2)
+  (write-integer-bytes num-channels 2)
+  (write-integer-bytes sample-rate)
+  ;; byte rate
+  (write-integer-bytes (* sample-rate num-channels bytes-per-sample))
+  ;; block align
+  (write-integer-bytes (* num-channels bytes-per-sample) 2)
+  (write-integer-bytes bits-per-sample 2)
+
+  ;; data subchunk
+  (write-bytes #"data")
+  (write-integer-bytes data-subchunk-size)
+  (for ([sample data])
+    (write-integer-bytes sample bytes-per-sample)))


### PR DESCRIPTION
This is incomplete. I can't yet compile main.rkt. When I uncomment the `(provide (except-out (all-from-out typed/racket) #%module-begin))`, I get the following error.

```
main.rkt:4:0: Type Checker: Error in macro expansion -- provide: for-meta not supported by Typed Racket
  in: (provide (except-out (all-from-out "synth.rkt" "sequencer.rkt" "mixer.rkt" "drum.rkt") mix sequence drum) (rename-out (mix/export mix) (sequence/export sequence) (drum/export drum) (#%module-begin/export #%module-begin)) (except-out (all-from-out typed/...
```

I'm really not sure what to do about that.
